### PR TITLE
Add support for self-signed minio deployments

### DIFF
--- a/src/clients/clients.go
+++ b/src/clients/clients.go
@@ -1,6 +1,13 @@
 package clients
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+
 	minio "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
@@ -10,14 +17,30 @@ import (
 	cnf "github.com/rzrbld/adminio-api/config"
 )
 
-var MadmClnt, MadmErr = madmin.New(cnf.Server, cnf.Maccess, cnf.Msecret, cnf.Ssl)
+var MadmErr error
+var MinioErr error
+var MinioClnt *minio.Client
+var MadmClnt *madmin.AdminClient
 
-// var MinioClnt, MinioErr = minio.New(cnf.Server, cnf.Maccess, cnf.Msecret, cnf.Ssl)
+func init() {
+	tr, err := customTransport()
+	if err != nil {
+		MadmErr = err
+		MinioErr = err
+		return
+	}
 
-var MinioClnt, MinioErr = minio.New(cnf.Server, &minio.Options{
-	Creds:  credentials.NewStaticV4(cnf.Maccess, cnf.Msecret, ""),
-	Secure: cnf.Ssl,
-})
+	MinioClnt, MinioErr = minio.New(cnf.Server, &minio.Options{
+		Creds:     credentials.NewStaticV4(cnf.Maccess, cnf.Msecret, ""),
+		Secure:    cnf.Ssl,
+		Transport: tr,
+	})
+
+	MadmClnt, MadmErr = madmin.New(cnf.Server, cnf.Maccess, cnf.Msecret, cnf.Ssl)
+	if err == nil {
+		MadmClnt.SetCustomTransport(tr)
+	}
+}
 
 func main() {
 	if MadmErr != nil {
@@ -27,4 +50,62 @@ func main() {
 	if MinioErr != nil {
 		log.Fatalln("Error while connecting via minio client ", MinioErr)
 	}
+}
+
+func customTransport() (*http.Transport, error) {
+
+	if !cnf.Ssl {
+		return minio.DefaultTransport(cnf.Ssl)
+	}
+
+	tlsConfig := &tls.Config{
+		// Can't use SSLv3 because of POODLE and BEAST
+		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+		// Can't use TLSv1.1 because of RC4 cipher usage
+		MinVersion: tls.VersionTLS12,
+	}
+
+	tr, err := minio.DefaultTransport(cnf.Ssl)
+	if err != nil {
+		return nil, err
+	}
+
+	if cnf.SSLCACertFile != "" {
+		minioCACert, err := os.ReadFile(cnf.SSLCACertFile)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isValidCertificate(minioCACert) {
+			return nil, fmt.Errorf("minio CA Cert is not a valid x509 certificate")
+		}
+
+		rootCAs, _ := x509.SystemCertPool()
+		if rootCAs == nil {
+			// In some systems (like Windows) system cert pool is
+			// not supported or no certificates are present on the
+			// system - so we create a new cert pool.
+			rootCAs = x509.NewCertPool()
+		}
+		rootCAs.AppendCertsFromPEM(minioCACert)
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	if cnf.SSLSkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	tr.TLSClientConfig = tlsConfig
+
+	return tr, nil
+}
+
+func isValidCertificate(c []byte) bool {
+	p, _ := pem.Decode(c)
+	if p == nil {
+		return false
+	}
+	_, err := x509.ParseCertificates(p.Bytes)
+	return err == nil
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -16,6 +16,8 @@ var (
 	// Enable object locking by default
 	DefaultObjectLocking, _ = strconv.ParseBool(getEnv("MINIO_DEFAULT_LOCK_OBLECT_ENABLE", "false"))
 	Ssl, _                  = strconv.ParseBool(getEnv("MINIO_SSL", "false"))
+	SSLSkipVerify, _        = strconv.ParseBool(getEnv("MINIO_SSL_INSECURE", "false"))
+	SSLCACertFile           = getEnv("MINIO_SSL_CACERT", "")
 	ServerHostPort          = getEnv("ADMINIO_HOST_PORT", "localhost:8080")
 	AdminioCORS             = getEnv("ADMINIO_CORS_DOMAIN", "*")
 	// AES only supports key sizes of 16, 24 or 32 bytes.


### PR DESCRIPTION
* Either by setting the environment variable `MINIO_SSL_INSECURE` to `true`
* or providing a CA certificate via a file specified by `MINIO_SSL_CACERT`

In the minio Terraform Provider in https://github.com/aminueza/terraform-provider-minio/pull/296 this will be used to test the behaviour of the provider with SSL active for minio and retaining the ability to inspect the state while testing.